### PR TITLE
Fixed:  Animated `useNativeDriver` was not specified

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,11 +89,13 @@ class ContentLoader extends Component {
     Animated.sequence([
       Animated.timing(this._animate, {
         toValue: 1,
-        duration: this.state.frequence
+        duration: this.state.frequence,
+        useNativeDriver: false
       }),
       Animated.timing(this._animate, {
         toValue: 0,
-        duration: this.state.frequence
+        duration: this.state.frequence,
+        useNativeDriver: false
       })
     ]).start(event => {
       if (event.finished) {


### PR DESCRIPTION
rn-content-loader outputs the following warning message form React Native v0.62.

<img width="241" alt="スクリーンショット 2020-05-08 15 32 35" src="https://user-images.githubusercontent.com/19209314/81467418-6a14bf80-9213-11ea-944d-f0ddc49ff9b8.png">

```
Animated: `useNativeDriver` was not specified
```